### PR TITLE
Further defines prop types, refactors index in .maps, updates formatting.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
-import "./styles/App.css";
-import DistrictRepository from "./helper";
-import kinderData from "./data/kindergartners_in_full_day_program.js";
-import CardContainer from "./components/CardContainer";
-import Search from "./components/Search";
-import Comparison from "./components/Comparison";
+import React, { Component } from 'react';
+import './styles/App.css';
+import DistrictRepository from './helper';
+import kinderData from './data/kindergartners_in_full_day_program.js';
+import CardContainer from './components/CardContainer';
+import Search from './components/Search';
+import Comparison from './components/Comparison';
 
 const kinderGardenData = new DistrictRepository(kinderData);
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,21 +1,20 @@
-import React from "react";
-import "../styles/Card.css";
-import PropTypes from "prop-types";
+import React from 'react';
+import '../styles/Card.css';
+import PropTypes from 'prop-types';
 
 const Card = ({ data, clickCard, selected }) => {
   const yearsArray = Object.keys(data.data);
   const percentArray = Object.values(data.data);
+
   const highlighted = selected.find(
     district => district.location === data.location
-  )
-    ? "highlighted"
-    : "";
+  ) ? 'highlighted': '';
 
   const elements = percentArray.map((percent, index) => {
-    let percentClass = "belowFifty";
+    let percentClass = 'belowFifty';
 
     if (percent >= 0.5) {
-      percentClass = "aboveFifty";
+      percentClass = 'aboveFifty';
     }
 
     return (
@@ -33,8 +32,6 @@ const Card = ({ data, clickCard, selected }) => {
     </article>
   );
 };
-
-// need prop types for clickCard, selected
 
 Card.prototype = {
   data: PropTypes.arrayOf(
@@ -55,6 +52,27 @@ Card.prototype = {
       }).isRequired
     })
   ).isRequired,
+
+  clickCard: PropTypes.func.isRequired,
+
+  selected: PropTypes.arrayOf(
+    PropTypes.shape({
+      location: PropTypes.string.isRequired,
+      data: PropTypes.shape({
+        2004: PropTypes.number.isRequired,
+        2005: PropTypes.number.isRequired,
+        2006: PropTypes.number.isRequired,
+        2007: PropTypes.number.isRequired,
+        2008: PropTypes.number.isRequired,
+        2009: PropTypes.number.isRequired,
+        2010: PropTypes.number.isRequired,
+        2011: PropTypes.number.isRequired,
+        2012: PropTypes.number.isRequired,
+        2013: PropTypes.number.isRequired,
+        2014: PropTypes.number.isRequired
+      }).isRequired
+    })
+  ).isRequired
 };
 
 export default Card;

--- a/src/components/CardContainer.js
+++ b/src/components/CardContainer.js
@@ -1,28 +1,46 @@
-import React from "react";
-import Card from "./Card";
-import "../styles/CardContainer.css";
-import PropTypes from "prop-types";
+import React from 'react';
+import Card from './Card';
+import '../styles/CardContainer.css';
+import PropTypes from 'prop-types';
 
 const CardContainer = ({ data, clickCard, selected }) => {
-  const renderedCards = data.map((district, index) => {
-    return <Card 
-      data={district} 
-      clickCard={clickCard} 
-      key={index} 
-      selected={selected}  />
+  const renderedCards = data.map(district => {
+    return (
+      <Card
+        data={district}
+        clickCard={clickCard}
+        key={district.location}
+        selected={selected}
+      />
+    );
   });
 
-  return (
-    <div className="CardContainer">
-      { renderedCards }
-    </div>
-  )
+  return <div className="CardContainer">{renderedCards}</div>;
 };
-
-// need prop types for clickCard, selecte
 
 CardContainer.propTypes = {
   data: PropTypes.arrayOf(
+    PropTypes.shape({
+      location: PropTypes.string.isRequired,
+      data: PropTypes.shape({
+        2004: PropTypes.number.isRequired,
+        2005: PropTypes.number.isRequired,
+        2006: PropTypes.number.isRequired,
+        2007: PropTypes.number.isRequired,
+        2008: PropTypes.number.isRequired,
+        2009: PropTypes.number.isRequired,
+        2010: PropTypes.number.isRequired,
+        2011: PropTypes.number.isRequired,
+        2012: PropTypes.number.isRequired,
+        2013: PropTypes.number.isRequired,
+        2014: PropTypes.number.isRequired
+      }).isRequired
+    })
+  ).isRequired,
+
+  clickCard: PropTypes.func.isRequired,
+
+  selected: PropTypes.arrayOf(
     PropTypes.shape({
       location: PropTypes.string.isRequired,
       data: PropTypes.shape({

--- a/src/components/Comparison.js
+++ b/src/components/Comparison.js
@@ -1,16 +1,16 @@
-import React from "react";
-import Card from "./Card";
-import "../styles/Comparison.css";
-import PropTypes from "prop-types";
+import React from 'react';
+import Card from './Card';
+import '../styles/Comparison.css';
+import PropTypes from 'prop-types';
 
 const Comparison = ({ data, clickCard, selected, getComparison }) => {
   const averageObj = getComparison(selected[0].location, selected[1].location);
-  const renderedCards = selected.map((district, index) => {
+  const renderedCards = selected.map(district => {
     return (
       <Card
         data={district}
         clickCard={clickCard}
-        key={index}
+        key={district.location}
         selected={selected}
       />
     );
@@ -32,8 +32,6 @@ const Comparison = ({ data, clickCard, selected, getComparison }) => {
   );
 };
 
-export default Comparison;
-
 Comparison.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
@@ -53,7 +51,29 @@ Comparison.propTypes = {
       }).isRequired
     })
   ).isRequired,
-  clickCard: PropTypes.func,
-  selected: PropTypes.array.isRequired, 
+
+  clickCard: PropTypes.func.isRequired,
+
+  selected: PropTypes.arrayOf(
+    PropTypes.shape({
+      location: PropTypes.string.isRequired,
+      data: PropTypes.shape({
+        2004: PropTypes.number.isRequired,
+        2005: PropTypes.number.isRequired,
+        2006: PropTypes.number.isRequired,
+        2007: PropTypes.number.isRequired,
+        2008: PropTypes.number.isRequired,
+        2009: PropTypes.number.isRequired,
+        2010: PropTypes.number.isRequired,
+        2011: PropTypes.number.isRequired,
+        2012: PropTypes.number.isRequired,
+        2013: PropTypes.number.isRequired,
+        2014: PropTypes.number.isRequired
+      }).isRequired
+    })
+  ).isRequired,
+
   getComparison: PropTypes.func.isRequired
 };
+
+export default Comparison;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,5 +1,5 @@
-import React, { Component } from "react";
-import "../styles/Search.css";
+import React, { Component } from 'react';
+import '../styles/Search.css';
 
 class Search extends Component {
   constructor(props) {
@@ -9,33 +9,38 @@ class Search extends Component {
     };
   }
 
-  handleInput = (e) => {
+  handleInput = e => {
     e.preventDefault();
     this.setState({
       display: e.target.value
-    })
-    this.props.searchDistrict(e.target.value)
-  }
+    });
+    this.props.searchDistrict(e.target.value);
+  };
 
-  handleButtonClick = (e) => {
+  handleButtonClick = e => {
     e.preventDefault();
-    this.props.searchDistrict(this.state.display)
-  }
+    this.props.searchDistrict(this.state.display);
+  };
 
   render() {
     return (
       <header>
         <form>
-          <label htmlFor="search-input">Search for your school district: </label>
-          <input id="search-input" 
-                 type="text" 
-                 value={ this.state.display }
-                 onChange={ this.handleInput }/>
-          <button className='search-button' 
-                  onClick={ this.handleButtonClick }>Submit</button> 
+          <label htmlFor="search-input">
+            Search for your school district:{' '}
+          </label>
+          <input
+            id="search-input"
+            type="text"
+            value={this.state.display}
+            onChange={this.handleInput}
+          />
+          <button className="search-button" onClick={this.handleButtonClick}>
+            Submit
+          </button>
         </form>
       </header>
-    )
+    );
   }
 }
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -39,6 +39,7 @@ export default class DistrictRepository {
 
   findAllMatches(string) {
     const districts = Object.keys(this.data);
+    
     if (!string) {
       return districts.reduce((accu, district) => {
         accu.push(this.data[district]);

--- a/src/test/unit/App.test.js
+++ b/src/test/unit/App.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
-import React from "react";
-import App from "../../App";
-import { shallow, mount, render } from "enzyme";
+import React from 'react';
+import App from '../../App';
+import { shallow, mount, render } from 'enzyme';
 import DistrictRepository from '../../helper';
 import kinderData from '../../data/kindergartners_in_full_day_program';
 
@@ -10,8 +10,8 @@ const kinderGardenData = new DistrictRepository(kinderData);
 describe('App', () => {
   let wrapper;
 
-  beforeEach( () => {
-    wrapper = shallow( <App /> )
+  beforeEach(() => {
+    wrapper = shallow(<App />);
   });
 
   it('exists and matches snapshot', () => {
@@ -21,7 +21,7 @@ describe('App', () => {
 
   it('Should start with default state property of data set to an array of all the cleaned district objects', () => {
     expect(wrapper.state().data.length).toEqual(181);
-    expect(wrapper.state().data[3].location).toEqual("ADAMS-ARAPAHOE 28J");
+    expect(wrapper.state().data[3].location).toEqual('ADAMS-ARAPAHOE 28J');
   });
 
   it('Should start with default state property of selected set to an empty array', () => {
@@ -43,8 +43,8 @@ describe('App', () => {
   it('When a user clicks a card, its district object should be added to the state.selected array', () => {
     expect(wrapper.state().selected).toEqual([]);
     wrapper.instance().clickCard('COLORADO');
-    expect(wrapper.state().selected[0].location).toEqual('COLORADO')
-  })
+    expect(wrapper.state().selected[0].location).toEqual('COLORADO');
+  });
 
   it('It does allow the user to select more than two cards', () => {
     expect(wrapper.state().selected).toEqual([]);
@@ -54,55 +54,96 @@ describe('App', () => {
     expect(wrapper.state().selected.length).toEqual(2);
     expect(wrapper.state().selected[0].location).toEqual('COLORADO SPRINGS 11');
     expect(wrapper.state().selected[1].location).toEqual('ADAMS-ARAPAHOE 28J');
-  })
+  });
 
   it('Upon clicking the card a second time its district object should be removed from the state.selected array', () => {
     expect(wrapper.state().selected).toEqual([]);
     wrapper.instance().clickCard('COLORADO');
-    expect(wrapper.state().selected[0].location).toEqual('COLORADO')
+    expect(wrapper.state().selected[0].location).toEqual('COLORADO');
     wrapper.instance().clickCard('COLORADO');
     expect(wrapper.state().selected).toEqual([]);
-  })
+  });
 
   it('It should have a method which takes in two school districts and returns an object with their averages', () => {
-    expect(wrapper.instance().getComparison('COLORADO', 'ACADEMY 20')).toEqual({'COLORADO': 0.53, 'ACADEMY 20': 0.407, 'compared': 1.302});
-  })
+    expect(wrapper.instance().getComparison('COLORADO', 'ACADEMY 20')).toEqual({
+      COLORADO: 0.53,
+      'ACADEMY 20': 0.407,
+      compared: 1.302
+    });
+  });
 
   it('should have a visual indication that cards are selected', () => {
-    let mountedWrapper = mount(<App />)
-    expect(mountedWrapper.find('article').first().hasClass('highlighted')).toEqual(false)
+    let mountedWrapper = mount(<App />);
+    expect(
+      mountedWrapper
+        .find('article')
+        .first()
+        .hasClass('highlighted')
+    ).toEqual(false);
 
-    mountedWrapper.find('Card').first().simulate('click');
-  
-    expect(mountedWrapper.find('article').first().hasClass('highlighted')).toEqual(true)
-  })
+    mountedWrapper
+      .find('Card')
+      .first()
+      .simulate('click');
+
+    expect(
+      mountedWrapper
+        .find('article')
+        .first()
+        .hasClass('highlighted')
+    ).toEqual(true);
+  });
 
   it('If clicked a second time, the district should revert back to its previous state', () => {
-    let mountedWrapper = mount(<App />)
-    expect(mountedWrapper.find('article').first().hasClass('highlighted')).toEqual(false)
+    let mountedWrapper = mount(<App />);
+    expect(
+      mountedWrapper
+        .find('article')
+        .first()
+        .hasClass('highlighted')
+    ).toEqual(false);
 
-    mountedWrapper.find('Card').first().simulate('click');
-    expect(mountedWrapper.find('article').first().hasClass('highlighted')).toEqual(true)
+    mountedWrapper
+      .find('Card')
+      .first()
+      .simulate('click');
+    expect(
+      mountedWrapper
+        .find('article')
+        .first()
+        .hasClass('highlighted')
+    ).toEqual(true);
 
-    mountedWrapper.find('Card').first().simulate('click');
-    expect(mountedWrapper.find('article').first().hasClass('highlighted')).toEqual(false)
-  })
+    mountedWrapper
+      .find('Card')
+      .first()
+      .simulate('click');
+    expect(
+      mountedWrapper
+        .find('article')
+        .first()
+        .hasClass('highlighted')
+    ).toEqual(false);
+  });
 
-  it ('when user clicks a card, those cards appear at the top of the app with an additional comparison card', () => {
-    let mountedWrapper = mount(<App />)
+  it('when user clicks a card, those cards appear at the top of the app with an additional comparison card', () => {
+    let mountedWrapper = mount(<App />);
     expect(mountedWrapper.state().data.length).toEqual(181);
-    expect(mountedWrapper.find('article').length).toEqual(181)
-    expect(mountedWrapper.find('Comparison').length).toEqual(0)
+    expect(mountedWrapper.find('article').length).toEqual(181);
+    expect(mountedWrapper.find('Comparison').length).toEqual(0);
 
-
-    mountedWrapper.find('Card').first().simulate('click');
-    mountedWrapper.find('Card').last().simulate('click');
+    mountedWrapper
+      .find('Card')
+      .first()
+      .simulate('click');
+    mountedWrapper
+      .find('Card')
+      .last()
+      .simulate('click');
 
     expect(mountedWrapper.state().data.length).toEqual(181);
     expect(mountedWrapper.find('article').length).toEqual(184);
 
-    expect(mountedWrapper.find('Comparison').length).toEqual(1)
-  })
-
-
+    expect(mountedWrapper.find('Comparison').length).toEqual(1);
+  });
 });

--- a/src/test/unit/Card.test.js
+++ b/src/test/unit/Card.test.js
@@ -1,36 +1,41 @@
 /* eslint-disable */
-import React from "react";
-import { shallow, mount, render } from "enzyme";
-import Card from "../../components/Card";
-import { cardData, selected } from "./mockData";
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+import Card from '../../components/Card';
+import { cardData, selected } from './mockData';
 
-describe("Card", () => {
+describe('Card', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<Card data={cardData.district} key={cardData.index} selected={selected}/>);
+    wrapper = shallow(
+      <Card data={cardData.district} key={cardData.index} selected={selected} />
+    );
   });
 
-  it("should exist", () => {
+  it('should exist', () => {
     expect(wrapper).toBeDefined();
   });
 
   it('should render 10 divs with data in them', () => {
-    expect(wrapper.find('.card-data-row').length).toEqual(11)
-  })
+    expect(wrapper.find('.card-data-row').length).toEqual(11);
+  });
 
   it('should render the district name as an h3', () => {
-    expect(wrapper.find('h3').first().text()).toEqual('COLORADO')
-  })
+    expect(
+      wrapper
+        .find('h3')
+        .first()
+        .text()
+    ).toEqual('COLORADO');
+  });
 
   it('should assign the percent class based on whether the value is over 0.5', () => {
-    expect(wrapper.find('.belowFifty').length).toEqual(4)
+    expect(wrapper.find('.belowFifty').length).toEqual(4);
     expect(wrapper.find('.aboveFifty').length).toEqual(7);
-  })
+  });
 
   it('should have a visual indication of being clicked when the district of that card is present in the selected array', () => {
     expect(wrapper.find('.highlighted').length).toEqual(1);
-  })
-
-  
+  });
 });

--- a/src/test/unit/CardContainer.test.js
+++ b/src/test/unit/CardContainer.test.js
@@ -1,23 +1,29 @@
 /* eslint-disable */
-import React from "react";
-import ReactDOM from "react-dom";
-import { shallow, mount, render } from "enzyme";
-import CardContainer from "../../components/CardContainer";
-import { containerData } from "./mockData";
-import Card from "../../components/Card";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow, mount, render } from 'enzyme';
+import CardContainer from '../../components/CardContainer';
+import { containerData, clickCard, selected } from './mockData';
+import Card from '../../components/Card';
 
-describe("CardContainer", () => {
+describe('CardContainer', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<CardContainer data={containerData} />);
+    wrapper = shallow(
+      <CardContainer
+        data={containerData}
+        clickCard={clickCard}
+        selected={selected}
+      />
+    );
   });
 
-  it("should exist", () => {
+  it('should exist', () => {
     expect(wrapper).toBeDefined();
   });
 
   it('should make 2 cards if 2 cards are passed into it', () => {
-    expect(wrapper.find('Card').length).toEqual(2)
-  })
+    expect(wrapper.find('Card').length).toEqual(2);
+  });
 });

--- a/src/test/unit/Comparison.test.js
+++ b/src/test/unit/Comparison.test.js
@@ -1,37 +1,43 @@
 /* eslint-disable */
-import React from "react";
-import { shallow, mount, render } from "enzyme";
-import Comparison from "../../components/Comparison";
-import { selected, containerData, cardData } from './mockData';
-import Card from "../../components/Card";
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+import Comparison from '../../components/Comparison';
+import {
+  selected,
+  containerData,
+  cardData,
+  clickCard,
+  getComparison
+} from './mockData';
+import Card from '../../components/Card';
 
-
-const getComparison = function () {
-  return {'COLORADO': 0.53, 'ACADEMY 20': 0.407, 'compared': 1.302}
-}
-
-
-describe("Comparison", () => {
+describe('Comparison', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<Comparison data={containerData} selected={selected} getComparison={getComparison} />);
+    wrapper = shallow(
+      <Comparison
+        data={containerData}
+        selected={selected}
+        getComparison={getComparison}
+        clickCard={clickCard}
+      />
+    );
   });
 
-  it("should exist", () => {
+  it('should exist', () => {
     expect(wrapper).toBeDefined();
   });
 
   it('should make 2 Card components if it receives a full selected array', () => {
-    expect(wrapper.find('Card').length).toEqual(2)
-  })
+    expect(wrapper.find('Card').length).toEqual(2);
+  });
 
   it('should render an average card in the middle of two Card components', () => {
     expect(wrapper).toMatchSnapshot();
-  }) 
+  });
 
   it('should display an average of the two districts', () => {
-    expect(wrapper.find('.compared').text()).toEqual('1.302')
-  })
-
+    expect(wrapper.find('.compared').text()).toEqual('1.302');
+  });
 });

--- a/src/test/unit/Search.test.js
+++ b/src/test/unit/Search.test.js
@@ -1,81 +1,74 @@
 /* eslint-disable */
-import React from "react";
-import { shallow, mount, render } from "enzyme";
-import Search from "../../components/Search";
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+import Search from '../../components/Search';
 import { containerData, cardData } from './mockData';
 
-const searchDistrict = function () {
+const searchDistrict = function() {
   return containerData;
-}
+};
 
 describe('Search', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<Search searchDistrict={ searchDistrict }/>); 
-  })
+    wrapper = mount(<Search searchDistrict={searchDistrict} />);
+  });
 
   it('exists', () => {
     expect(wrapper).toBeDefined();
-  })
+  });
 
   it('should start out with a state with display set to an empty string', () => {
     expect(wrapper.state().display).toEqual('');
-  })
+  });
 
   it('should have a label, input field, and a button in a form element', () => {
     expect(wrapper).toMatchSnapshot();
-  })
+  });
 
   it('should take a search input and set state.display to that input', () => {
     const event = {
-     preventDefault() {},
-     target: {value: 'colorado'}}
-    expect(wrapper.state().display).toEqual('');    
+      preventDefault() {},
+      target: { value: 'colorado' }
+    };
+    expect(wrapper.state().display).toEqual('');
     expect(wrapper.find('input').text()).toEqual('');
 
     wrapper.instance().handleInput(event);
 
     expect(wrapper.state().display).toEqual('colorado');
-  })
+  });
 
   it('sends the input text to searchDistrict method which will return an array of district objects', () => {
     const event = {
-     preventDefault() {},
-     target: {value: 'colorado'}}
+      preventDefault() {},
+      target: { value: 'colorado' }
+    };
     wrapper.instance().handleInput(event);
-    expect(wrapper.instance().props.searchDistrict(event.target.value)).toEqual(containerData)
-  })
+    expect(wrapper.instance().props.searchDistrict(event.target.value)).toEqual(
+      containerData
+    );
+  });
 
   it('user should be able to pass in a case insensitive query', () => {
     const event = {
-     preventDefault() {},
-     target: {value: 'cOlOraDo'}}
+      preventDefault() {},
+      target: { value: 'cOlOraDo' }
+    };
     wrapper.instance().handleInput(event);
-    expect(wrapper.instance().props.searchDistrict(event.target.value)).toEqual(containerData)
-  })
+    expect(wrapper.instance().props.searchDistrict(event.target.value)).toEqual(
+      containerData
+    );
+  });
 
   it('has a button which sends the input text to searchDistrict method which will return an array of district objects', () => {
-    expect(wrapper.state().display).toEqual('')
+    expect(wrapper.state().display).toEqual('');
 
-    wrapper.find('input').simulate('change', {target: {value: 'Bou'}})
+    wrapper.find('input').simulate('change', { target: { value: 'Bou' } });
     wrapper.find('button').simulate('click');
-    
-    expect(wrapper.state().display).toEqual('Bou')
-  })
 
-  it.skip('upon typing, user should see what they are typing via state.display ', () => {
-    expect(wrapper.find('input').text()).toEqual('')
-    const event = {
-     preventDefault() {},
-     target: {value: 'colorado'}}
+    expect(wrapper.state().display).toEqual('Bou');
+  });
 
-    wrapper.find('input').simulate('change', event)
-
-    expect(wrapper.state().display).toEqual(''); //when this is also colorado it's weird
-    expect(wrapper.find('input').text()).toEqual('colorado');
-  })
-
-
-
-})
+});

--- a/src/test/unit/__snapshots__/Comparison.test.js.snap
+++ b/src/test/unit/__snapshots__/Comparison.test.js.snap
@@ -5,6 +5,7 @@ exports[`Comparison should render an average card in the middle of two Card comp
   className="Comparison"
 >
   <Card
+    clickCard={[Function]}
     data={
       Object {
         "data": Object {
@@ -23,7 +24,7 @@ exports[`Comparison should render an average card in the middle of two Card comp
         "location": "COLORADO",
       }
     }
-    key="0"
+    key="COLORADO"
     selected={
       Array [
         Object {
@@ -86,6 +87,7 @@ exports[`Comparison should render an average card in the middle of two Card comp
     </h3>
   </article>
   <Card
+    clickCard={[Function]}
     data={
       Object {
         "data": Object {
@@ -104,7 +106,7 @@ exports[`Comparison should render an average card in the middle of two Card comp
         "location": "COLORADO SPRINGS 11",
       }
     }
-    key="1"
+    key="COLORADO SPRINGS 11"
     selected={
       Array [
         Object {

--- a/src/test/unit/__snapshots__/Search.test.js.snap
+++ b/src/test/unit/__snapshots__/Search.test.js.snap
@@ -9,7 +9,8 @@ exports[`Search should have a label, input field, and a button in a form element
       <label
         htmlFor="search-input"
       >
-        Search for your school district: 
+        Search for your school district:
+         
       </label>
       <input
         id="search-input"

--- a/src/test/unit/mockData.js
+++ b/src/test/unit/mockData.js
@@ -94,3 +94,31 @@ export const selected = [
   }
 ]
 
+export const clickCard = string => {
+  const clickedDistrict = kinderGardenData.findByName(string);
+
+  if (
+    this.state.selected.length < 2 &&
+    !this.state.selected.includes(clickedDistrict)
+  ) {
+    const selected = [...this.state.selected, clickedDistrict];
+
+    this.setState({ selected });
+  } else if (!this.state.selected.includes(clickedDistrict)) {
+    const district = [...this.state.selected].pop();
+    const selected = [district, clickedDistrict];
+
+    this.setState({ selected });
+  } else {
+    const remaining = this.state.selected.filter(
+      district => clickedDistrict.location !== district.location
+    );
+    const selected = [...remaining];
+
+    this.setState({ selected });
+  }
+};
+
+export const getComparison = () => {
+  return {'COLORADO': 0.53, 'ACADEMY 20': 0.407, 'compared': 1.302}
+}


### PR DESCRIPTION
Props types are more explicit for all components.  Testing mock data updated so that each test component in test receives its expected prop type. Removed the key={index} from all maps except in Card.js Elements.map because the item we are mapping over is a data type of number. We do not have access to the location string here.  Can’t use the number itself because many are the number 1. Updates formatting so the quotes are consistent.  